### PR TITLE
Minor bug fixed

### DIFF
--- a/src/fast5_interface.c
+++ b/src/fast5_interface.c
@@ -188,7 +188,7 @@ char * read_string_attribute(hid_t group, const char * attribute){
     } else {
         // Fixed length
         size_t asize = H5Tget_size(atype);
-        str = calloc(asize, sizeof(char));
+        str = calloc(asize + 1, sizeof(char));
         herr_t err = H5Aread(attr, atype, str);
         if(err < 0){
             warnx("Failed to copy attribute '%s'.", attribute);

--- a/src/flappie.c
+++ b/src/flappie.c
@@ -269,7 +269,8 @@ static struct _raw_basecall_info calculate_post(char * filename, enum model_type
         .quality = quality,
         .basecall_length = basecall_length,
         .trace = trace,
-        .pos = pos};
+        .pos = pos,
+        .nblock = nblock};
 }
 
 


### PR DESCRIPTION
* Return number of blocks, not zero, in basecall results
* Make sure strings read from HDF are null-terminated