### PR TITLE
5mC model with correct scaling

### DIFF
--- a/misc/parse_flipflop_guppy.py
+++ b/misc/parse_flipflop_guppy.py
@@ -8,15 +8,19 @@
 #  http://nanoporetech.com
 
 import argparse
-import pickle
 import math
 import numpy as np
+import pickle
 import re
 import sys
 
+from sloika.cmdargs import AutoBool, FileExists
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--id', default='' , help='Identifier for model names')
-parser.add_argument('model', help='Pickle to read model from')
+parser.add_argument('--scale', default=False, action=AutoBool,
+                    help='Correct scaling when network trained without MAD factor')
+parser.add_argument('model', action=FileExists, help='Pickle to read model from')
 
 
 trim_trailing_zeros = re.compile('0+p')
@@ -80,6 +84,9 @@ if __name__ == '__main__':
     """
 
     filterW =  network.sublayers[0].W.get_value()
+    if args.scale:
+        #  Scaling factor for MAD
+        filterW *= 1.4826
     nfilter, _ , winlen = filterW.shape
     cformatM(sys.stdout, 'conv_rnnrf_flipflop_{}W'.format(modelid), filterW.reshape(-1, 1), nr = winlen * 4 - 3, nc=nfilter)
     cformatV(sys.stdout, 'conv_rnnrf_flipflop_{}b'.format(modelid), network.sublayers[0].b.get_value().reshape(-1))

--- a/src/fast5_interface.c
+++ b/src/fast5_interface.c
@@ -336,8 +336,12 @@ void write_summary(hid_t hdf5file, const char *readname,
     herr_t status = write_signal(read_group, res.rt.raw + res.rt.start,
                                  nsample, chunk_size, compression_level);
 
-    herr_t status2 = write_trace(read_group, res.trace->data.f, res.trace->nr, res.trace->nc,
-                                 chunk_size, compression_level);
+    int32_t * trace_flat = array_from_flappie_imatrix(res.trace);
+    if(NULL != trace_flat){
+        herr_t status2 = write_trace(read_group, trace_flat, res.trace->nr, res.trace->nc,
+                                     chunk_size, compression_level);
+        free(trace_flat);
+    }
 
     H5Gclose(read_group);
 

--- a/src/flappie_matrix.c
+++ b/src/flappie_matrix.c
@@ -50,6 +50,7 @@ flappie_matrix make_flappie_matrix(size_t nr, size_t nc) {
     return mat;
 }
 
+
 flappie_matrix remake_flappie_matrix(flappie_matrix M, size_t nr, size_t nc) {
     // Could be made more efficient when there is sufficent memory already allocated
     if ((NULL == M) || (M->nr != nr) || (M->nc != nc)) {
@@ -58,6 +59,7 @@ flappie_matrix remake_flappie_matrix(flappie_matrix M, size_t nr, size_t nc) {
     }
     return M;
 }
+
 
 flappie_matrix copy_flappie_matrix(const_flappie_matrix M){
     RETURN_NULL_IF(NULL == M, NULL);
@@ -74,6 +76,7 @@ void zero_flappie_matrix(flappie_matrix M) {
     }
     memset(M->data.f, 0, M->stride * M->nc * sizeof(float));
 }
+
 
 flappie_matrix mat_from_array(const float *x, size_t nr, size_t nc) {
     flappie_matrix res = make_flappie_matrix(nr, nc);
@@ -228,6 +231,7 @@ bool validate_flappie_matrix(flappie_matrix mat, float lower,
 }
 #endif /* NDEBUG */
 
+
 /**  Check whether two matrices are equal within a given tolerance
  *
  *  @param mat1 A `flappie_matrix` to compare
@@ -275,6 +279,7 @@ bool equality_flappie_matrix(const_flappie_matrix mat1,
     return true;
 }
 
+
 flappie_imatrix make_flappie_imatrix(size_t nr, size_t nc) {
     assert(nr > 0);
     assert(nc > 0);
@@ -297,6 +302,7 @@ flappie_imatrix make_flappie_imatrix(size_t nr, size_t nc) {
     return mat;
 }
 
+
 flappie_imatrix remake_flappie_imatrix(flappie_imatrix M, size_t nr, size_t nc) {
     // Could be made more efficient when there is sufficent memory already allocated
     if ((NULL == M) || (M->nr != nr) || (M->nc != nc)) {
@@ -306,6 +312,7 @@ flappie_imatrix remake_flappie_imatrix(flappie_imatrix M, size_t nr, size_t nc) 
     return M;
 }
 
+
 flappie_imatrix copy_flappie_imatrix(const_flappie_imatrix M){
     RETURN_NULL_IF(NULL == M, NULL);
     flappie_imatrix C = make_flappie_imatrix(M->nr, M->nc);
@@ -313,6 +320,7 @@ flappie_imatrix copy_flappie_imatrix(const_flappie_imatrix M){
     memcpy(C->data.f, M->data.f, sizeof(__m128i) * C->nrq * C->nc);
     return C;
 }
+
 
 flappie_imatrix free_flappie_imatrix(flappie_imatrix mat) {
     if (NULL != mat) {
@@ -322,12 +330,33 @@ flappie_imatrix free_flappie_imatrix(flappie_imatrix mat) {
     return NULL;
 }
 
+
 void zero_flappie_imatrix(flappie_imatrix M) {
     if (NULL == M) {
         return;
     }
     memset(M->data.f, 0, M->stride * M->nc * sizeof(int));
 }
+
+
+int32_t * array_from_flappie_imatrix(const_flappie_imatrix mat){
+    RETURN_NULL_IF(NULL == mat, NULL);
+
+    const size_t nelt = mat->nr * mat->nc;
+    int32_t * res = calloc(nelt, sizeof(int32_t));
+    RETURN_NULL_IF(NULL == res, NULL);
+
+    for(size_t c=0 ; c < mat->nc ; c++){
+        const size_t offset_out = c * mat->nr;
+        const size_t offset_in = c * mat->stride;
+        for(size_t r=0 ; r < mat->nr ; r++){
+            res[offset_out + r] = mat->data.f[offset_in + r];
+        }
+    }
+
+    return res;
+}
+
 
 flappie_matrix affine_map(const_flappie_matrix X, const_flappie_matrix W,
                            const_flappie_matrix b, flappie_matrix C) {
@@ -358,6 +387,7 @@ flappie_matrix affine_map(const_flappie_matrix X, const_flappie_matrix W,
 
     return C;
 }
+
 
 flappie_matrix affine_map2(const_flappie_matrix Xf, const_flappie_matrix Xb,
                             const_flappie_matrix Wf, const_flappie_matrix Wb,
@@ -390,6 +420,7 @@ flappie_matrix affine_map2(const_flappie_matrix Xf, const_flappie_matrix Xb,
                 C->data.f, C->stride);
     return C;
 }
+
 
 void row_normalise_inplace(flappie_matrix C) {
     if (NULL == C) {
@@ -453,6 +484,7 @@ float max_flappie_matrix(const_flappie_matrix x) {
     return amax;
 }
 
+
 float min_flappie_matrix(const_flappie_matrix x) {
     if (NULL == x) {
         // Input NULL due to earlier failure.  Propagate
@@ -469,6 +501,7 @@ float min_flappie_matrix(const_flappie_matrix x) {
     }
     return amin;
 }
+
 
 int argmax_flappie_matrix(const_flappie_matrix x) {
     if (NULL == x) {
@@ -490,6 +523,7 @@ int argmax_flappie_matrix(const_flappie_matrix x) {
     return imax;
 }
 
+
 int argmin_flappie_matrix(const_flappie_matrix x) {
     if (NULL == x) {
         // Input NULL due to earlier failure.  Propagate
@@ -509,6 +543,7 @@ int argmin_flappie_matrix(const_flappie_matrix x) {
     }
     return imin;
 }
+
 
 bool validate_vector(float *vec, const size_t n, const float lower,
                      const float upper, const char *file, const int line) {

--- a/src/flappie_matrix.h
+++ b/src/flappie_matrix.h
@@ -58,6 +58,7 @@ flappie_imatrix remake_flappie_imatrix(flappie_imatrix M, size_t nr, size_t nc);
 flappie_imatrix copy_flappie_imatrix(const_flappie_imatrix mat);
 flappie_imatrix free_flappie_imatrix(flappie_imatrix mat);
 void zero_flappie_imatrix(flappie_imatrix M);
+int32_t * array_from_flappie_imatrix(const_flappie_imatrix mat);
 
 flappie_matrix affine_map(const_flappie_matrix X, const_flappie_matrix W,
                            const_flappie_matrix b, flappie_matrix C);

--- a/src/models/flipflop_20181217_r941native5mC_4ad3b85.mdl
+++ b/src/models/flipflop_20181217_r941native5mC_4ad3b85.mdl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2015bffdb61b0389174ce2be46ff2e41ae9efaf1332fef6638b8b8e41cf67838
+size 30778937

--- a/src/models/flipflop_r941native5mC.h
+++ b/src/models/flipflop_r941native5mC.h
@@ -1,1 +1,1 @@
-flipflop_20181126_r941native5mC_4ad3b85.mdl
+flipflop_20181217_r941native5mC_4ad3b85.mdl


### PR DESCRIPTION
5mC model was incorrectly scaled, resulting in poor basecalls.
Also fixes issue with trace output when modified bases are present.